### PR TITLE
Improve build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ MACRO(CHECK_REQUIRED_LIB2 upper lower header lower2 header2)
     ELSE (${upper}_INCLUDE_PATH)
 		FIND_PATH(${upper}_INCLUDE_PATH ${header2} $ENV{${upper}DIR}/include ${INCLUDE_DIRS})
     ENDIF(${upper}_INCLUDE_PATH)
-    
+
     IF(${upper}_INCLUDE_PATH)
-		FIND_LIBRARY(${upper}_LIBRARY NAMES ${lower} ${lower2} PATHS $ENV{${upper}DIR}/lib ${LIB_DIRS})		
+		FIND_LIBRARY(${upper}_LIBRARY NAMES ${lower} ${lower2} PATHS $ENV{${upper}DIR}/lib ${LIB_DIRS})
 		IF(${upper}_LIBRARY)
 		ELSE(${upper}_LIBRARY)
 			MESSAGE(SEND_ERROR "ERROR: ${upper} not found. please install ${upper} first!")
@@ -71,7 +71,7 @@ IF(ENABLE_EMAN2)
     INCLUDE_DIRECTORIES(${EMAN2_INCLUDE_PATH})
 	target_link_libraries(
 		dosefgpu_driftcorr
-		${EMAN_LIBRARIES}	
+		${EMAN_LIBRARIES}
 )
 ENDIF(ENABLE_EMAN2)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,13 +6,13 @@ NVCC =  nvcc
 
 
 DoseFProject: func.cpp mrc.cpp
-	g++ ${CPPFLAG} -c func.cpp -o func.o 
+	g++ ${CPPFLAG} -c func.cpp -o func.o
 	g++ ${CPPFLAG} -c mrc.cpp -o mrc.o
 	g++ ${CPPFLAG} -c dim.cpp -o dim.o
 	${NVCC} ${CUFLAG} -c cufunc.cu -o cufunc.o
 	${NVCC} ${CUFLAG} -c DFAlign.cpp -o DFAlign.o
 	g++ -O3 -c safefft.cpp -o safefft.o
 	${NVCC} ${CUFLAG} ${CULIBFLAG} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
-	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo	
+	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,3 @@
-
 CPPFLAGS = -static -I./SP++3/include
 CXXFLAGS = -O3
 CUFLAGS = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,12 +6,12 @@ NVCC = nvcc
 
 
 DoseFProject: cufunc.o func.o mrc.o dim.o safefft.o
-	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
-	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
-	${NVCC} -O3 gpuinfo.cu -o ../bin/gpuinfo
+	$(NVCC) $(CUFLAGS) -c DFAlign.cpp -o DFAlign.o
+	$(NVCC) $(CUFLAGS) $(CULIBFLAGS) dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
+	$(NVCC) -O3 gpuinfo.cu -o ../bin/gpuinfo
 
 %.o : %.cu
-	${NVCC} ${CUFLAGS} -c $< -o $@
+	$(NVCC) $(CUFLAGS) -c $< -o $@
 
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,5 +10,6 @@ DoseFProject: func.o mrc.o dim.o safefft.o
 	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
 	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	${NVCC} -O3 gpuinfo.cu -o ../bin/gpuinfo
+
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,13 +6,9 @@ CULIBFLAGS = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -l
 NVCC =  nvcc
 
 
-DoseFProject: func.cpp mrc.cpp
-	g++ ${CPPFLAGS} ${CXXFLAGS} -c func.cpp -o func.o
-	g++ ${CPPFLAGS} ${CXXFLAGS} -c mrc.cpp -o mrc.o
-	g++ ${CPPFLAGS} ${CXXFLAGS} -c dim.cpp -o dim.o
+DoseFProject: func.o mrc.o dim.o safefft.o
 	${NVCC} ${CUFLAGS} -c cufunc.cu -o cufunc.o
 	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
-	g++ ${CXXFLAGS} -c safefft.cpp -o safefft.o
 	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,19 +1,19 @@
 
-CPPFLAG = -static -I./SP++3/include
+CPPFLAGS = -static -I./SP++3/include
 CXXFLAGS = -O3
-CUFLAG = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
-CULIBFLAG = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -lm
+CUFLAGS = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
+CULIBFLAGS = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -lm
 NVCC =  nvcc
 
 
 DoseFProject: func.cpp mrc.cpp
-	g++ ${CPPFLAG} ${CXXFLAGS} -c func.cpp -o func.o
-	g++ ${CPPFLAG} ${CXXFLAGS} -c mrc.cpp -o mrc.o
-	g++ ${CPPFLAG} ${CXXFLAGS} -c dim.cpp -o dim.o
-	${NVCC} ${CUFLAG} -c cufunc.cu -o cufunc.o
-	${NVCC} ${CUFLAG} -c DFAlign.cpp -o DFAlign.o
+	g++ ${CPPFLAGS} ${CXXFLAGS} -c func.cpp -o func.o
+	g++ ${CPPFLAGS} ${CXXFLAGS} -c mrc.cpp -o mrc.o
+	g++ ${CPPFLAGS} ${CXXFLAGS} -c dim.cpp -o dim.o
+	${NVCC} ${CUFLAGS} -c cufunc.cu -o cufunc.o
+	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
 	g++ ${CXXFLAGS} -c safefft.cpp -o safefft.o
-	${NVCC} ${CUFLAG} ${CULIBFLAG} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
+	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 CPPFLAGS = -static -I./SP++3/include
 CXXFLAGS = -O3
-CUFLAGS = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
+NVGPUARCH = sm_20
+CUFLAGS = -O3 -lcuda -lcufft -arch=$(NVGPUARCH)  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
 CULIBFLAGS = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -lm
 NVCC = nvcc
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,7 @@ CULIBFLAGS = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -l
 NVCC = nvcc
 
 
-DoseFProject: func.o mrc.o dim.o safefft.o
-	${NVCC} ${CUFLAGS} -c cufunc.cu -o cufunc.o
+DoseFProject: cufunc.o func.o mrc.o dim.o safefft.o
 	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
 	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	${NVCC} -O3 gpuinfo.cu -o ../bin/gpuinfo

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ CPPFLAGS = -static -I./SP++3/include
 CXXFLAGS = -O3
 CUFLAGS = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
 CULIBFLAGS = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -lm
-NVCC =  nvcc
+NVCC = nvcc
 
 
 DoseFProject: func.o mrc.o dim.o safefft.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,6 @@ DoseFProject: func.o mrc.o dim.o safefft.o
 	${NVCC} ${CUFLAGS} -c cufunc.cu -o cufunc.o
 	${NVCC} ${CUFLAGS} -c DFAlign.cpp -o DFAlign.o
 	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
-	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo
+	${NVCC} -O3 gpuinfo.cu -o ../bin/gpuinfo
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,5 +11,8 @@ DoseFProject: func.o mrc.o dim.o safefft.o
 	${NVCC} ${CUFLAGS} ${CULIBFLAGS} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	${NVCC} -O3 gpuinfo.cu -o ../bin/gpuinfo
 
+%.o : %.cu
+	${NVCC} ${CUFLAGS} -c $< -o $@
+
 clean:
 	rm -rf *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,17 +1,18 @@
 
-CPPFLAG = -static -O3 -I./SP++3/include
+CPPFLAG = -static -I./SP++3/include
+CXXFLAGS = -O3
 CUFLAG = -O3 -lcuda -lcufft -arch=sm_20  -Xptxas -dlcm=ca  -lpthread -I./SP++3/include
 CULIBFLAG = cufunc.o DFAlign.o func.o mrc.o dim.o safefft.o -L./lib -lfftw3f -lm
 NVCC =  nvcc
 
 
 DoseFProject: func.cpp mrc.cpp
-	g++ ${CPPFLAG} -c func.cpp -o func.o
-	g++ ${CPPFLAG} -c mrc.cpp -o mrc.o
-	g++ ${CPPFLAG} -c dim.cpp -o dim.o
+	g++ ${CPPFLAG} ${CXXFLAGS} -c func.cpp -o func.o
+	g++ ${CPPFLAG} ${CXXFLAGS} -c mrc.cpp -o mrc.o
+	g++ ${CPPFLAG} ${CXXFLAGS} -c dim.cpp -o dim.o
 	${NVCC} ${CUFLAG} -c cufunc.cu -o cufunc.o
 	${NVCC} ${CUFLAG} -c DFAlign.cpp -o DFAlign.o
-	g++ -O3 -c safefft.cpp -o safefft.o
+	g++ ${CXXFLAGS} -c safefft.cpp -o safefft.o
 	${NVCC} ${CUFLAG} ${CULIBFLAG} dosefgpu_driftcorr.cpp -o ../bin/dosefgpu_driftcorr
 	nvcc -O3 gpuinfo.cu -o ../bin/gpuinfo
 clean:


### PR DESCRIPTION
Correct and clean up the build system.

The Makefile for [GNU Make](https://www.gnu.org/software/make/) is improved to use implicit rules, and
the dependencies are corrected, so that more things are built in parallel now.

Using variables for the tool chain programs, these can be set now like below for example.

```
$ cd src/
$ make CXX=clang++ CXXFLAGS="-Wall" -j
```